### PR TITLE
gpt 3.5 => gpt 4o mini

### DIFF
--- a/plotbot/plotbot.py
+++ b/plotbot/plotbot.py
@@ -101,7 +101,7 @@ def show_llm_params():
 
 def initialize_state():
     if "openai_model" not in st.session_state:
-        st.session_state["openai_model"] = "gpt-3.5-turbo"
+        st.session_state["openai_model"] = "gpt-4o-mini"
 
     if "messages" not in st.session_state:
         st.session_state["messages"] = [
@@ -184,7 +184,7 @@ def generate_plot_code(df, user_request, schema):
     
     try:
         response = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=st.session_state["openai_model"],
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
                 {"role": "user", "content": prompt}


### PR DESCRIPTION
As suggest in reddit, there is no reason to use 3.5. 4o mini is [3x as cheap](https://context.ai/compare/gpt-4o-mini/gpt-3-5-turbo) and performs better on all metrics.

Additionally, you initalised the model in `initialize_state`, but didnt use it in the actual API call on line 187.